### PR TITLE
Reorder tabs to prioritize Recruitment

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -137,7 +137,7 @@ const Select = ({ value, onChange, options, placeholder }) => (
 
 // ---------- App shell ----------
 function AppShell({ children, current, setCurrent }) {
-  const tabs = ["Dashboard","Follow-Ups","Recruitment","Termination","KPI","Settings"];
+  const tabs = ["Dashboard","Recruitment","Follow-Ups","Termination","KPI","Settings"];
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900 p-6">
       <div className="max-w-7xl mx-auto space-y-6">


### PR DESCRIPTION
## Summary
- Move Recruitment tab before Follow-Ups in the navigation menu

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cbb16a0f0832f82c8ffa4dd2566ef