### PR TITLE
Persist selected view in filter bar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,9 +169,16 @@ function FiltersBar({ filters, setFilters, savedViews, setSavedViews }) {
 
   const saveView = () => {
     const name = prompt("Name this view"); if (!name) return;
-    const copy = { ...(savedViews || {}) }; copy[name] = filters; setSavedViews(copy);
+    const copy = { ...(savedViews || {}) };
+    copy[name] = { ...filters, view: name };
+    setSavedViews(copy);
+    setFilters({ ...filters, view: name });
   };
-  const loadView = (name) => { if (!name) return; const conf = savedViews?.[name]; if (conf) setFilters(conf); };
+  const loadView = (name) => {
+    if (!name) return;
+    const conf = savedViews?.[name];
+    if (conf) setFilters({ ...conf, view: name });
+  };
 
   return (
     <div className="bg-white rounded-2xl p-3 border shadow-sm flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## Summary
- Include view name when saving a view and set it as active
- Restore view name when loading saved filters

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ccf4dfb00832f8150708b3c0d50d7