### PR TITLE
Handle localStorage setItem errors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,7 +83,13 @@ const useLocalState = (key, initial) => {
     try { const raw = localStorage.getItem(key); return raw ? JSON.parse(raw) : initial; }
     catch { return initial; }
   });
-  useEffect(() => { localStorage.setItem(key, JSON.stringify(state)); }, [key, state]);
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(state));
+    } catch (e) {
+      console.error("Failed to save to localStorage", e);
+    }
+  }, [key, state]);
   return [state, setState];
 };
 


### PR DESCRIPTION
## Summary
- wrap `localStorage.setItem` in `useLocalState` with try/catch to avoid crashes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ccf54916c832fb53a946e9577b5b2