### PR TITLE
fix: enable termination date input

### DIFF
--- a/src/components/Termination.jsx
+++ b/src/components/Termination.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 function Termination({ drivers, up, can }) {
-  const active = drivers.filter(d => d.status !== 'Terminated');
-  const leavers = drivers.filter(d => d.status === 'Terminated');
+  const active = drivers.filter(d => d.status !== 'Terminated' || !d.termDate);
+  const leavers = drivers.filter(d => d.status === 'Terminated' && d.termDate);
 
   return (
     <section className="space-y-4">

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+import process from 'node:process'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 


### PR DESCRIPTION
## Summary
- keep newly terminated drivers in active list until a termination date is entered
- import node `process` in Vite config to satisfy lint

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cdedabc64832faee08b54d5643f44