### PR TITLE
feat: add uuid helper

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import Settings from "./components/Settings";
 import FiltersBar from "./components/FiltersBar";
 import { parseISO, addDaysLocal, todayLocalISO, firstOfMonth, lastOfMonth, ym, fmtPct } from "./lib/date";
 import { LS_KEY, useLocalState } from "./lib/storage";
+import { uuid } from "./lib/uuid";
 
 // ---------- CSV helpers ----------
 const escapeCSV = (s) => {
@@ -64,7 +65,7 @@ const fromCSVFile = async (file) => parseCSVText(await file.text());
 
 // ---------- Master data model ----------
 const newDriver = () => ({
-  id: crypto.randomUUID(),
+  id: uuid(),
   name: "",
   recruiter: "",
   source: "",

--- a/src/lib/uuid.js
+++ b/src/lib/uuid.js
@@ -1,0 +1,9 @@
+export const uuid = () => (
+  typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID()
+    : 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+        const r = Math.random() * 16 | 0;
+        const v = c === 'x' ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+      })
+);


### PR DESCRIPTION
## Summary
- add uuid utility with crypto.randomUUID fallback
- use uuid helper for new driver IDs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cf0dc61a0832f8b5742b9ce53a596