### PR TITLE
fix: prevent implicit form submission in Button

### DIFF
--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -9,6 +9,7 @@ function Button({ variant = 'primary', className = '', loading = false, disabled
   };
   return (
     <button
+      type="button"
       className={`btn ${variants[variant] || ''} ${className}`}
       disabled={disabled || loading}
       {...props}


### PR DESCRIPTION
## Summary
- add default `type="button"` to Button component to avoid unintended form submissions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cf0dc7ba8832f9dea8a053dad947d