### PR TITLE
Ensure new drivers appear when filters active

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -537,9 +537,11 @@ export default function App() {
       return true;
     };
     return arr.filter(d => {
-      if (filters.recruiter && d.recruiter !== filters.recruiter) return false;
-      if (filters.source && d.source !== filters.source) return false;
-      if (!within(d.startDate)) return false;
+      // Allow editing newly-added drivers even if filters are active by
+      // only applying the filters when the driver has values for them.
+      if (filters.recruiter && d.recruiter && d.recruiter !== filters.recruiter) return false;
+      if (filters.source && d.source && d.source !== filters.source) return false;
+      if (d.startDate && !within(d.startDate)) return false;
       return true;
     });
   }, [drivers, filters]);


### PR DESCRIPTION
## Summary
- Allow new drivers to remain visible even when recruiter, source, or date filters are applied

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cf28dfbf0832f9a3f5e1f58611e86