### PR TITLE
feat: scroll to newly added driver rows

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -604,13 +604,14 @@ export default function App() {
             recruiters={RECRUITERS}
             sources={SOURCES}
           />
-          <DriversTable
-            drivers={filteredDrivers}
-            up={up}
-            addDriver={addDriver}
-            recruiters={RECRUITERS}
-            sources={SOURCES}
-          />
+            <DriversTable
+              drivers={filteredDrivers}
+              up={up}
+              addDriver={addDriver}
+              recruiters={RECRUITERS}
+              sources={SOURCES}
+              recentDriverId={recentDriverId}
+            />
         </div>
       )}
       {tab === "Termination" && (
@@ -623,7 +624,7 @@ export default function App() {
             recruiters={RECRUITERS}
             sources={SOURCES}
           />
-          <Termination drivers={filteredDrivers} up={up} can={can} />
+            <Termination drivers={filteredDrivers} up={up} can={can} recentDriverId={recentDriverId} />
         </div>
       )}
       {tab === "KPI" && <KPI monthly={monthly} />}

--- a/src/components/DriversTable.jsx
+++ b/src/components/DriversTable.jsx
@@ -5,7 +5,17 @@ import { Table, Thead, Tbody, Tr, Th, Td } from './ui/Table';
 import Input from './ui/Input';
 import Select from './ui/Select';
 
-function DriversTable({ drivers, up, addDriver, recruiters, sources }) {
+import { useEffect } from 'react';
+
+function DriversTable({ drivers, up, addDriver, recruiters, sources, recentDriverId }) {
+  useEffect(() => {
+    if (!recentDriverId) return;
+    const el = document.getElementById(`driver-row-${recentDriverId}`);
+    if (el && 'scrollIntoView' in el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [recentDriverId, drivers.length]);
+
   return (
     <div className="section space-y-6">
       <Card>
@@ -27,7 +37,7 @@ function DriversTable({ drivers, up, addDriver, recruiters, sources }) {
             </Thead>
             <Tbody>
               {drivers.map((d) => (
-                <Tr key={d.id}>
+                <Tr key={d.id} id={`driver-row-${d.id}`}>
                   <Td><Input value={d.name} onChange={(e) => up(d.id, { name: e.target.value })} placeholder="Driver" className="w-40" /></Td>
                   <Td><Select value={d.recruiter} onChange={(e) => up(d.id, { recruiter: e.target.value })} className="w-36"><option value="">—</option>{recruiters.map(r => <option key={r}>{r}</option>)}</Select></Td>
                   <Td><Select value={d.source} onChange={(e) => up(d.id, { source: e.target.value })} className="w-36"><option value="">—</option>{sources.map(s => <option key={s}>{s}</option>)}</Select></Td>

--- a/src/components/Termination.jsx
+++ b/src/components/Termination.jsx
@@ -1,13 +1,21 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Card, CardHeader, CardBody } from './ui/Card';
 import { Table, Thead, Tbody, Tr, Th, Td } from './ui/Table';
 import Input from './ui/Input';
 import Select from './ui/Select';
 import Button from './ui/Button';
 
-function Termination({ drivers, up, can }) {
+function Termination({ drivers, up, can, recentDriverId }) {
   const active = drivers.filter(d => d.status !== 'Terminated' || !d.termDate);
   const leavers = drivers.filter(d => d.status === 'Terminated' && d.termDate);
+
+  useEffect(() => {
+    if (!recentDriverId) return;
+    const el = document.getElementById(`driver-row-${recentDriverId}`);
+    if (el && 'scrollIntoView' in el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [recentDriverId, drivers.length]);
 
   return (
     <div className="section space-y-6">
@@ -28,10 +36,10 @@ function Termination({ drivers, up, can }) {
               </Tr>
             </Thead>
             <Tbody>
-              {active.map(d => {
-                const needsDate = (d.status === 'Terminated' && !d.termDate);
-                return (
-                  <Tr key={d.id}>
+                {active.map(d => {
+                  const needsDate = (d.status === 'Terminated' && !d.termDate);
+                  return (
+                    <Tr key={d.id} id={`driver-row-${d.id}`}>
                     <Td>{d.name || '—'}</Td>
                     <Td>{d.recruiter || '—'}</Td>
                     <Td>{d.startDate || '—'}</Td>
@@ -110,8 +118,8 @@ function Termination({ drivers, up, can }) {
               </Tr>
             </Thead>
             <Tbody>
-              {leavers.map(d => (
-                <Tr key={d.id}>
+                {leavers.map(d => (
+                  <Tr key={d.id} id={`driver-row-${d.id}`}>
                   <Td>{d.name}</Td>
                   <Td>{d.recruiter || '—'}</Td>
                   <Td>{d.startDate || '—'}</Td>


### PR DESCRIPTION
## Summary
- automatically scroll recruitment and termination tables to newly added driver
- forward recent driver state to tables for auto-focus

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d01242320832fab983a6e3e9b8bae