### PR TITLE
fix: use default import for user management

### DIFF
--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import UserManagement from '@/components/settings/UserManagement';
+
+/**
+ * Settings page groups various configuration sections.
+ */
+const Settings: React.FC = () => {
+  return (
+    <div className="space-y-6">
+      <UserManagement />
+    </div>
+  );
+};
+
+export default Settings;

--- a/src/components/settings/UserManagement.tsx
+++ b/src/components/settings/UserManagement.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+/**
+ * User management settings section.
+ * Placeholder component until full implementation is provided.
+ */
+const UserManagement: React.FC = () => {
+  return (
+    <div className="p-4">
+      <h2 className="text-lg font-semibold mb-2">User Management</h2>
+      <p className="text-sm text-gray-600">Manage application users here.</p>
+    </div>
+  );
+};
+
+export default UserManagement;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,21 @@
 /* eslint-env node */
 import process from 'node:process'
+import path, { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
   base: process.env.BASE_PATH || '/',
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src')
+    }
+  },
   test: {
     environment: 'jsdom'
   }


### PR DESCRIPTION
## Summary
- add placeholder UserManagement component and import it in Settings using default export
- configure Vite alias for '@' to resolve to src directory

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3a2b1a514832fba4c950d2625d76e